### PR TITLE
Add instructions for running and debugging the claim-process service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,82 @@
+# Byte-compiled files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution/Packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+# Usually these files are written by a Python script from a template
+# before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / Coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+pytest_cache/
+.pytest_cache/
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+
+# IDEs and editors
+# PyCharm
+.idea/
+# VS Code
+.vscode/
+*.code-workspace
+# Sublime Text
+*.sublime-workspace
+*.sublime-project
+
+# MacOS
+.DS_Store
+
+# Logs
+*.log
+
+# Docker-related
+*.env
+*.env.*
+*.dockerignore
+docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Define the service name and command to exec
+SERVICE_NAME = claim-process
+CONTAINER_SHELL = /bin/bash  # Use /bin/sh if bash is not available
+
+# .PHONY target to prevent make from confusing these with filenames
+.PHONY: up down ssh logs build rebuild test help
+
+# Start the containers
+up:
+	@echo "Starting the containers in detached mode."
+	docker-compose up -d
+
+
+# Stop the containers
+down:
+	@echo "Stopping the containers and removing any running instances."
+	docker-compose down
+
+
+# Enter the container's shell
+ssh:
+	@echo "Connecting to the container's shell."
+	docker-compose exec $(SERVICE_NAME) $(CONTAINER_SHELL)
+
+# Tail the logs of the container
+logs:
+	@echo "Displaying logs for the container, follow with -f for continuous output."
+	docker-compose logs -f $(SERVICE_NAME)
+
+# Build the container without starting it
+build:
+	@echo "Building the Docker image without starting the containers."
+	docker-compose build
+
+# Rebuild the containers and start them
+rebuild:
+	@echo "Rebuilding the Docker images and starting the containers."
+	docker-compose up -d --build
+
+# Run tests using pytest inside the container
+test:
+	@echo "Running tests using pytest inside the container."
+	docker-compose run --rm $(SERVICE_NAME) pytest -s $(file)
+
+# Show available commands and explanations
+help:
+	@echo "Available commands:"
+	@echo "  up       - Start the containers (detached mode)."
+	@echo "  down     - Stop and remove the containers."
+	@echo "  ssh      - Enter the container's shell for interactive commands."
+	@echo "  logs     - Tail the logs of the container (use -f for continuous output)."
+	@echo "  build    - Build the container image without starting the service."
+	@echo "  rebuild  - Rebuild the containers and restart them."
+	@echo "  test     - Run pytest inside the container (you can specify a test file using 'file')."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Claim Process Service
+
+This repository contains the Claim Process service that processes claims, handles the data and logic for claim submission. The service is built with **FastAPI** and follows modern development practices using Docker for containerization and **pytest** for unit testing.
+
+## Running the Application
+
+To get started with the project, you'll need Docker and Docker Compose installed. The application runs in containers, and the following commands can help you manage the development environment.
+
+### Prerequisites
+
+- [Docker](https://www.docker.com/get-started) and [Docker Compose](https://docs.docker.com/compose/)
+- Python 3.10 or above (for development and debugging)
+
+### Start the Services
+
+To start the containers, run the following command:
+
+```bash
+make up
+```
+
+This will start all necessary containers in detached mode (in the background).
+
+### Running Unit Tests
+
+To run the unit tests for the `claim_process` service, use the following command:
+
+```bash
+make test
+```
+
+To run tests for a specific file, specify the file path as an argument:
+
+```bash
+make test file=tests/test_claim.py
+```
+
+### Debugging with `ipdb`
+
+To debug the service with `ipdb`, insert breakpoints where you want to inspect the code:
+
+```bash
+import ipdb; ipdb.set_trace()
+```
+
+And then execute the tests with: `make test`.


### PR DESCRIPTION
## Description
- Created a README.md file with detailed instructions on how to set up, run, and debug the claim-process service.
- Enhanced the Makefile with a help command providing descriptions for each target.
- Included steps for setting up unit tests and debugging with ipdb.