### PR TITLE
Implement /top-providers/ endpoint and add unit tests

### DIFF
--- a/claim-process/app/tests/conftest.py
+++ b/claim-process/app/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from ..database import get_session, engine
 from sqlmodel import SQLModel
+from ..models import Claim
 
 @pytest.fixture(autouse=True, scope="function")
 def create_test_database():
@@ -29,3 +30,45 @@ def session():
     # Rollback session after each test to ensure a clean state
     session.rollback()
     session.close()
+
+# Test setup to insert sample data
+@pytest.fixture
+def insert_sample_data(session):
+    # Prepare some sample data with at least 13 claims, including duplicate provider_npi
+    sample_claims = [
+        {"provider_npi": "1234567890", "net_fee": 5000.0, "provider_fees": 1000.0, "allowed_fees": 2000.0, "member_coinsurance": 100.0, "member_copay": 50.0},
+        {"provider_npi": "2345678901", "net_fee": 4500.0, "provider_fees": 1200.0, "allowed_fees": 1800.0, "member_coinsurance": 150.0, "member_copay": 75.0},
+        {"provider_npi": "3456789012", "net_fee": 4000.0, "provider_fees": 1100.0, "allowed_fees": 1700.0, "member_coinsurance": 120.0, "member_copay": 80.0},
+        {"provider_npi": "4567890123", "net_fee": 3500.0, "provider_fees": 1300.0, "allowed_fees": 1600.0, "member_coinsurance": 90.0, "member_copay": 60.0},
+        {"provider_npi": "5678901234", "net_fee": 3000.0, "provider_fees": 1000.0, "allowed_fees": 1500.0, "member_coinsurance": 80.0, "member_copay": 50.0},
+        {"provider_npi": "6789012345", "net_fee": 2500.0, "provider_fees": 900.0, "allowed_fees": 1400.0, "member_coinsurance": 70.0, "member_copay": 40.0},
+        {"provider_npi": "7890123456", "net_fee": 2000.0, "provider_fees": 800.0, "allowed_fees": 1300.0, "member_coinsurance": 60.0, "member_copay": 30.0},
+        {"provider_npi": "8901234567", "net_fee": 1500.0, "provider_fees": 700.0, "allowed_fees": 1200.0, "member_coinsurance": 50.0, "member_copay": 25.0},
+        {"provider_npi": "9012345678", "net_fee": 1000.0, "provider_fees": 600.0, "allowed_fees": 1100.0, "member_coinsurance": 40.0, "member_copay": 20.0},
+        {"provider_npi": "0123456789", "net_fee": 500.0, "provider_fees": 500.0, "allowed_fees": 1000.0, "member_coinsurance": 30.0, "member_copay": 10.0},
+        {"provider_npi": "2233445566", "net_fee": 4700.0, "provider_fees": 1500.0, "allowed_fees": 2500.0, "member_coinsurance": 130.0, "member_copay": 70.0},
+        {"provider_npi": "3344556677", "net_fee": 3900.0, "provider_fees": 1400.0, "allowed_fees": 2200.0, "member_coinsurance": 110.0, "member_copay": 60.0},
+        {"provider_npi": "4455667788", "net_fee": 3200.0, "provider_fees": 1300.0, "allowed_fees": 2100.0, "member_coinsurance": 100.0, "member_copay": 55.0},
+        # Duplicates for verification of summation
+        {"provider_npi": "1234567890", "net_fee": 2000.0, "provider_fees": 900.0, "allowed_fees": 1800.0, "member_coinsurance": 50.0, "member_copay": 25.0},
+        {"provider_npi": "2345678901", "net_fee": 1000.0, "provider_fees": 1100.0, "allowed_fees": 1500.0, "member_coinsurance": 60.0, "member_copay": 30.0}
+    ]
+    
+    # Insert claims into the database
+    for claim_data in sample_claims:
+        claim = Claim(
+            provider_npi=claim_data["provider_npi"],
+            net_fee=claim_data["net_fee"],
+            service_date="2025-01-01",
+            submitted_procedure="procedure_code",
+            quadrant="A",
+            plan_group="group1",
+            subscriber="subscriber1",
+            provider_fees=claim_data["provider_fees"],
+            allowed_fees=claim_data["allowed_fees"],
+            member_coinsurance=claim_data["member_coinsurance"],
+            member_copay=claim_data["member_copay"]
+        )
+        session.add(claim)
+    session.commit()
+

--- a/claim-process/app/tests/test_main.py
+++ b/claim-process/app/tests/test_main.py
@@ -173,3 +173,29 @@ def test_process_claim_missing_fields(session):
     total_claims = len(results)
 
     assert total_claims == 0
+
+# Test function for the get_top_providers endpoint
+def test_get_top_providers_with_duplicate_providers(insert_sample_data, session):
+
+    # Send GET request to the /top-providers/ endpoint
+    response = client.get("/top-providers/")
+
+    # Assert that the response status code is 200 (OK)
+    assert response.status_code == 200
+
+    # Assert that the response JSON contains the correct data structure
+    data = response.json()
+    assert "top_providers" in data
+    assert len(data["top_providers"]) == 10  # Ensure 10 providers are returned
+
+    # Check that the first provider has the highest net fee (including duplicated NPI)
+    assert data["top_providers"][0]["provider_npi"] == "1234567890"
+    assert data["top_providers"][0]["total_net_fee"] == 7000.0  # Sum of 5000.0 + 2000.0
+
+    # Check that the second provider is the one with the next highest net fee (including duplicated NPI)
+    assert data["top_providers"][1]["provider_npi"] == "2345678901"
+    assert data["top_providers"][1]["total_net_fee"] == 5500.0  # Sum of 4500.0 + 1000.0
+
+    # Check that the last provider has the lowest net fee
+    assert data["top_providers"][-1]["provider_npi"] == "7890123456"
+    assert data["top_providers"][-1]["total_net_fee"] == 2000

--- a/claim-process/requirements.txt
+++ b/claim-process/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 alembic
 psycopg2-binary==2.9.10
 sqlmodel==0.0.22
+slowapi
 sqlalchemy
 pytest
 httpx


### PR DESCRIPTION
## Description

This PR implements the /top-providers/ endpoint, which returns the top 10 providers based on the sum of their net_fee. The query aggregates net_fee for each provider_npi, orders them by the total net_fee in descending order, and returns the top 10.

Additionally, unit tests are written for the endpoint to verify its functionality. These tests insert sample claims into the database and ensure that the endpoint correctly calculates the sum of net_fee for each provider_npi, including handling duplicate provider_npi values. The tests also verify that the correct data structure is returned.